### PR TITLE
Make template friendlier for code reloading

### DIFF
--- a/dev/cljs/precept/todomvc/app.cljs
+++ b/dev/cljs/precept/todomvc/app.cljs
@@ -3,6 +3,6 @@
             [figwheel.client :as figwheel :include-macros true]))
 
 (figwheel/watch-and-reload
-  :on-jsload core/mount-components)
+  :on-jsload #'core/mount-components)
 
 (core/main)

--- a/src/cljs/precept/todomvc/core.cljs
+++ b/src/cljs/precept/todomvc/core.cljs
@@ -17,7 +17,7 @@
 
 (defroute "/:filter" [filter] (then (visibility-filter (keyword filter))))
 
-(def history
+(defonce history
   (doto (History.)
     (events/listen EventType.NAVIGATE (fn [event] (secretary/dispatch! (.-token event))))
     (.setEnabled true)))


### PR DESCRIPTION
Before the change to make the history object a defonce, I was getting this error
in the console:

```
Failed to execute 'write' on 'Document': It isn't possible to write into a
document from an asynchronously-loaded external script unless it is explicitly
opened.
```

I also fixed the on-jsload function to reload updated versions of the var.